### PR TITLE
Use `safe_load` in PyYAML instead of `load`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 psycopg2==2.7.5
-PyYAML==3.12
+PyYAML==6.0

--- a/room_with_a_view/__init__.py
+++ b/room_with_a_view/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Unlimited Labs"""
 __email__ = 'hello@b12.io'
-__version__ = '0.1.4'
+__version__ = '0.1.5'

--- a/room_with_a_view/room_with_a_view.py
+++ b/room_with_a_view/room_with_a_view.py
@@ -93,7 +93,7 @@ class RoomWithAViewCommand(object):
 
         try:
             with open(self.options.settings, 'r') as stream:
-                settings = yaml.load(stream)
+                settings = yaml.safe_load(stream)
                 connection_options = settings['connections'].get(
                     self.options.connection)
                 if not connection_options:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.1.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/b12io/room_with_a_view',
-    version='0.1.4',
+    version='0.1.5',
     zip_safe=False,
 )


### PR DESCRIPTION
This PR updates PyYAML to 6.0 and uses `safe_load` instead of `load`, as `load` in PyYAML 6.0 requires an additional `Loader` positional argument and `load` is unsafe to use as arbituary python objects can be created from using it. 
https://pyyaml.org/wiki/PyYAMLDocumentation

Related issue: https://github.com/yaml/pyyaml/issues/576